### PR TITLE
scoping issue

### DIFF
--- a/src/services/mailjet.js
+++ b/src/services/mailjet.js
@@ -236,7 +236,7 @@ class MailJetService extends NotificationService {
       }
     })
 
-    const status = await sendEmail(sendOptions)
+    const status = await this.sendEmail(sendOptions)
 
     return { to: sendOptions.to, status, data: sendOptions }
   }


### PR DESCRIPTION
Not having this makes resending email from admin fail with a 'sendEmail' is not defined' error.